### PR TITLE
Delete 'get all client profile' method

### DIFF
--- a/src/main/java/com/marketplace/onlinemarketplace/service/ClientProfileService.java
+++ b/src/main/java/com/marketplace/onlinemarketplace/service/ClientProfileService.java
@@ -74,11 +74,5 @@ public class ClientProfileService {
         existingClientProfile.setIndustry(profileRequest.getIndustry());
 
         return clientProfileRepo.save(existingClientProfile);
-
-    }
-
-    public List<ClientProfile> getAllClientProfile() {
-        return clientProfileRepo.findAll();
-
     }
 }


### PR DESCRIPTION
The 'get all client profile' method has been deleted from the ClientProfileService as per the task requirement.