### PR TITLE
Remove getAllClientProfile method from ClientProfileService

### DIFF
--- a/src/main/java/com/marketplace/onlinemarketplace/service/ClientProfileService.java
+++ b/src/main/java/com/marketplace/onlinemarketplace/service/ClientProfileService.java
@@ -74,11 +74,5 @@ public class ClientProfileService {
         existingClientProfile.setIndustry(profileRequest.getIndustry());
 
         return clientProfileRepo.save(existingClientProfile);
-
-    }
-
-    public List<ClientProfile> getAllClientProfile() {
-        return clientProfileRepo.findAll();
-
     }
 }


### PR DESCRIPTION
This PR removes the getAllClientProfile method from the ClientProfileService. This change updates the service to no longer provide functionality for retrieving all client profiles.