### PR TITLE
Remove getAllClientProfile method from ClientProfileService

### DIFF
--- a/src/main/java/com/marketplace/onlinemarketplace/service/ClientProfileService.java
+++ b/src/main/java/com/marketplace/onlinemarketplace/service/ClientProfileService.java
@@ -74,11 +74,5 @@ public class ClientProfileService {
         existingClientProfile.setIndustry(profileRequest.getIndustry());
 
         return clientProfileRepo.save(existingClientProfile);
-
-    }
-
-    public List<ClientProfile> getAllClientProfile() {
-        return clientProfileRepo.findAll();
-
     }
 }


### PR DESCRIPTION
This PR removes the getAllClientProfile method from the ClientProfileService. This method was previously responsible for retrieving all client profiles from the system. The removal of this method indicates that the functionality to fetch all client profiles in bulk is no longer supported in the service layer.