### PR TITLE
Add delete method to BidService

### DIFF
--- a/src/main/java/com/marketplace/service/BidService.java
+++ b/src/main/java/com/marketplace/service/BidService.java
@@ -1,0 +1,30 @@
+package com.marketplace.service;
+
+import java.util.Date;
+import java.util.List;
+import com.marketplace.model.Bid;
+import com.marketplace.repository.BidRepository;
+
+public class BidService {
+    private BidRepository bidRepository;
+
+    public BidService(BidRepository bidRepository) {
+        this.bidRepository = bidRepository;
+    }
+
+    // Existing methods for creating, updating, and retrieving bids
+
+    /**
+     * Deletes all bids older than the specified date.
+     *
+     * @param date the date to compare bids against
+     */
+    public void deleteBidsOlderThan(Date date) {
+        List<Bid> bids = bidRepository.findAll();
+        for (Bid bid : bids) {
+            if (bid.getDate().before(date)) {
+                bidRepository.delete(bid);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request adds a new method to the BidService class that allows for the deletion of bids older than a specified date. The method iterates through all bids and removes those that are older than the given date, integrating with the existing data access layer.