### PR TITLE
Add method to get all bids by ID in Bid Service

### DIFF
--- a/src/main/java/com/marketplace/onlinemarketplace/repository/BidRepo.java
+++ b/src/main/java/com/marketplace/onlinemarketplace/repository/BidRepo.java
@@ -10,6 +10,8 @@ public interface BidRepo extends JpaRepository<Bid, Long> {
     List<Bid> findByProjectId(Long projectId);
     List<Bid> findByProjectIdAndStatus(Long projectId, Bid.BidStatus status);
 
+    List<Bid> findByFreelancerId(Long freelancerId);
+
     void deleteByBidDateBefore(LocalDateTime date);
 
 

--- a/src/main/java/com/marketplace/onlinemarketplace/service/BidService.java
+++ b/src/main/java/com/marketplace/onlinemarketplace/service/BidService.java
@@ -102,6 +102,10 @@ public class BidService {
         return bidRepo.findAll();
     }
 
+    public List<Bid> getAllBidsByFreelancerId(Long freelancerId) {
+        return bidRepo.findByFreelancerId(freelancerId);
+    }
+
     public void deleteBidsBefore(LocalDateTime date) {
         bidRepo.deleteByBidDateBefore(date);
     }


### PR DESCRIPTION
This pull request adds a new method in the Bid Service to retrieve all bids by their ID. This feature is essential for querying bid data efficiently.